### PR TITLE
feat: add remote backend config and improve webhook validation

### DIFF
--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,7 +1,14 @@
+# REMOTE BACKEND
+
+variable "bucket_name" {
+  type = string
+  default = ""
+}
+
 # API GATEWAY 
 variable "rest_api_name" {
   type    = string
-  default = ""
+  default = "gitlab-webhook"
 }
 
 variable "rest_api_path" {

--- a/webhook-producer/src/index.ts
+++ b/webhook-producer/src/index.ts
@@ -9,6 +9,16 @@ const gitlabToken = process.env.GITLAB_TOKEN
 export const handler = async ( e : APIGatewayProxyEvent ) : Promise<APIGatewayProxyResult>=> {
     const body = e.body? JSON.parse(e.body) : {}
 
+    if(!e.headers){
+        return {
+            statusCode: 400,
+            body: JSON.stringify({
+                success: false,
+                error: "Missing required headers"
+            })
+        }
+    }
+
     if(!e.headers['x-gitlab-token']){
         return {
             statusCode: 400,


### PR DESCRIPTION
- Add bucket_name variable for remote backend configuration
- Set default rest_api_name to "gitlab-webhook"
- Add headers validation in webhook handler before token check